### PR TITLE
RFR: Remove st2callback action

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,3 @@ packages =
 [entry_points]
 mistral.actions =
     st2.action = st2mistral.actions.stackstorm:St2Action
-    st2.callback = st2mistral.actions.stackstorm:St2Callback


### PR DESCRIPTION
* st2 now actively polls mistral for execution results. Therefore,
st2callback action is not needed anymore.