### PR TITLE
Allow skip_notify to match all tasks

### DIFF
--- a/st2mistral/actions/stackstorm.py
+++ b/st2mistral/actions/stackstorm.py
@@ -143,7 +143,7 @@ class St2Action(base.Action):
         skip_notify_tasks = self.st2_context.get('skip_notify_tasks', [])
         task_name = self.action_context.get('task_name', 'unknown')
 
-        if task_name not in skip_notify_tasks:
+        if task_name not in skip_notify_tasks and '*' not in skip_notify_tasks:
             # We only include notifications settings if the task is not to be skipped
             body['notify'] = notify
 


### PR DESCRIPTION
[Also open to a disable_notify parameter or some other implementation.]

An action can now contain the following to avoid all task notification:

```
skip_notify:
    default:
        - "*"
```

Otherwise the action must be updated every time new tasks are added to the
workflow.
