### PR TITLE
Remove py tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,4 +6,4 @@ dependencies:
 
 test:
   override:
-    - tox -e py27,pep8
+    - tox -e pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py34,py27,pep8
+envlist = pep8
 minversion = 1.6
 skipsdist = True
 


### PR DESCRIPTION
Change tox to only test pep8. Skip py35, py34, and py27 since code requires mistral and it's package separately. Testing of code is already covered in the mistral CI.