### PR TITLE
Fix st2 integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 # The order of packages is significant, because pip processes them in the order
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
+
+retrying<1.4,>=1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,5 @@ packages =
 mistral.actions =
     st2.action = st2mistral.actions.stackstorm:St2Action
 
-mistral.yaql_functions =
+mistral.expression.functions =
     st2kv = st2mistral.functions.stackstorm:st2kv_


### PR DESCRIPTION
Minor fixes to the mistral integration with st2. Merge this patch only when st2's mistral fork is caught up with upstream.