### PR TITLE
Remove python-mistralclient from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-git+https://github.com/StackStorm/python-mistralclient.git#egg=python-mistralclient
 retrying<1.4,>=1.3


### PR DESCRIPTION
This is causing conflict during build. python-mistralclient is already included in requirements in mistral and st2.