### PR TITLE
Deprecate /actionexecutions endpoint

### DIFF
--- a/st2mistral/actions/stackstorm.py
+++ b/st2mistral/actions/stackstorm.py
@@ -80,7 +80,7 @@ class St2Action(base.Action):
             )
         )
 
-        endpoint = self.st2_context['api_url'] + '/actionexecutions'
+        endpoint = self.st2_context['api_url'] + '/executions'
 
         st2_action_context = {
             'parent': self.st2_context.get('parent'),


### PR DESCRIPTION
We wanted to do that for [some time](https://github.com/StackStorm/st2/blame/master/st2api/st2api/controllers/v1/root.py#L51) already. Since it would be quite tricky to keep both endpoints in OpenAPI spec format, this seem like a good time to finally put the endpoint to rest.